### PR TITLE
🧹 cleanup unused function update_renv_cache

### DIFF
--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -146,19 +146,6 @@ install_renvvv() {
     Rscript -e "remotes::install_github('MiguelRodo/renvvv', upgrade = 'never')"
 }
 
-update_renv_cache() {
-    if [ "$SET_R_LIB_PATHS" = "true" ]; then
-        # Ensure the R library script is executable
-        chmod 755 scripts/r-lib-update.sh
-
-        # Execute the R library script
-        if ! bash scripts/r-lib-update.sh; then
-            echo "Failed to update R library environment variables"
-        fi
-    fi
-    
-}
-
 # Save original token values (used for restoring after install)
 _ORIG_GITHUB_TOKEN=""
 _ORIG_GITHUB_PAT=""


### PR DESCRIPTION
🎯 **What:** Removed the unused `update_renv_cache` function from `src/renv-cache/install.sh`.
💡 **Why:** This improves maintainability and readability by eliminating dead code that was not called anywhere in the script.
✅ **Verification:** Verified by running `bash -n src/renv-cache/install.sh` to ensure no syntax errors were introduced.
✨ **Result:** A cleaner and more maintainable `install.sh` script.

---
*PR created automatically by Jules for task [5098994772824395874](https://jules.google.com/task/5098994772824395874) started by @MiguelRodo*