### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal vulnerability in cmdstan installation script

### DIFF
--- a/src/cmdstan/install.sh
+++ b/src/cmdstan/install.sh
@@ -18,8 +18,8 @@ CMDSTAN_VERSION="${VERSION:-"latest"}"
 INSTALL_DIR="${INSTALLDIR:-"/opt/cmdstan"}"
 
 # 🛡️ Sentinel: Validate INSTALL_DIR to prevent path and command injection
-if ! echo "${INSTALL_DIR}" | grep -Eq '^/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$'; then
-    echo "Error: Invalid INSTALL_DIR '${INSTALL_DIR}'. Must be an absolute path containing only safe characters." >&2
+if ! echo "${INSTALL_DIR}" | grep -Eq '^/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$' || echo "${INSTALL_DIR}" | grep -Fq '..'; then
+    echo "Error: Invalid INSTALL_DIR '${INSTALL_DIR}'. Must be an absolute path containing only safe characters and no path traversal." >&2
     exit 1
 fi
 

--- a/test_su_correct.sh
+++ b/test_su_correct.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-USERNAME=$(whoami)
-su -s /bin/bash "$USERNAME" -c 'echo "0: $0"; echo "1: $1"; echo "2: $2"; exec echo "args:" "$@"' -- bash "config_file" "-i" "input.mmd"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `INSTALL_DIR` parameter in the `cmdstan` DevContainer feature installation script (`src/cmdstan/install.sh`) was validated with a regex (`^/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$`) that allowed the literal dot `.` character. Because it lacked a restriction on consecutive dots, an attacker could supply `..` in the path (e.g., `/opt/cmdstan/../../../etc/malicious`).
🎯 Impact: Exploitation of this vulnerability could allow an attacker to traverse directories and unintentionally write or overwrite files outside the intended installation directory when the script extracts the CmdStan archive with `tar`.
🔧 Fix: Updated the conditional logic to explicitly check for the `..` sequence using `|| echo "${INSTALL_DIR}" | grep -Fq '..'` and updated the accompanying error message to note the path traversal restriction.
✅ Verification: Tested manually with `INSTALLDIR="/opt/cmdstan/../../../etc/passwd" sudo bash src/cmdstan/install.sh` to confirm the input is rejected by the new validation rule.

---
*PR created automatically by Jules for task [11433109535617272675](https://jules.google.com/task/11433109535617272675) started by @MiguelRodo*