### PR TITLE
Security fix to prevent accidental rm -rf /* in renv-cache

### DIFF
--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -89,8 +89,24 @@ empty_dir() {
     local directory="$1"
 
     # 🛡️ Sentinel: Security fix to prevent accidental rm -rf /*
-    if [ -z "$directory" ] || [ "$directory" = "/" ]; then
-        echo "[ERROR] Refusing to empty directory: '$directory'"
+    if [[ -z "$directory" ]] || [[ "$directory" != /* ]]; then
+        echo "[ERROR] Refusing to empty directory: '$directory' (not an absolute path)"
+        return 1
+    fi
+
+    # Block path traversal and root-equivalent segments ( . and .. )
+    if [[ "$directory" == *"/./"* || "$directory" == *"/../"* || "$directory" == "/." || "$directory" == "/.." || "$directory" == */. || "$directory" == */.. ]]; then
+        echo "[ERROR] Refusing to empty directory: '$directory' (unsafe segment: . or ..)"
+        return 1
+    fi
+
+    # Block root aliases (/, //, etc.)
+    local normalized="${directory}"
+    while [[ "$normalized" != "/" && "$normalized" == */ ]]; do
+        normalized="${normalized%/}"
+    done
+    if [[ "$normalized" == "/" ]] || [[ "$normalized" == "//" ]] || [[ -z "$normalized" ]]; then
+        echo "[ERROR] Refusing to empty directory: '$directory' (resolves to root)"
         return 1
     fi
 
@@ -109,8 +125,25 @@ rm_dirs() {
     fi
 
     for dir in "$@"; do
-        if [ -z "$dir" ] || [ "$dir" = "/" ]; then
-            echo "[ERROR] Refusing to remove directory: '$dir'"
+        # 🛡️ Sentinel: Security fix to prevent accidental rm -rf /*
+        if [[ -z "$dir" ]] || [[ "$dir" != /* ]]; then
+            echo "[ERROR] Refusing to remove directory: '$dir' (not an absolute path)"
+            continue
+        fi
+
+        # Block path traversal and root-equivalent segments ( . and .. )
+        if [[ "$dir" == *"/./"* || "$dir" == *"/../"* || "$dir" == "/." || "$dir" == "/.." || "$dir" == */. || "$dir" == */.. ]]; then
+            echo "[ERROR] Refusing to remove directory: '$dir' (unsafe segment: . or ..)"
+            continue
+        fi
+
+        # Block root aliases (/, //, etc.)
+        local normalized="${dir}"
+        while [[ "$normalized" != "/" && "$normalized" == */ ]]; do
+            normalized="${normalized%/}"
+        done
+        if [[ "$normalized" == "/" ]] || [[ "$normalized" == "//" ]] || [[ -z "$normalized" ]]; then
+            echo "[ERROR] Refusing to remove directory: '$dir' (resolves to root)"
             continue
         fi
 


### PR DESCRIPTION
This PR implements a critical security fix in `src/renv-cache/install.sh` to prevent accidental deletion of the root directory or unintended paths via `rm -rf`. 

The original validation was a simple check against `/`, which could be bypassed by root-equivalent aliases like `/.` or `//`. The updated logic:
1. Forces absolute paths.
2. Rejects any path containing `..` or `.` segments (e.g., `/../`, `/.`).
3. Normalizes trailing slashes to correctly identify root-equivalent paths.
4. Leverages Bash-specific features (as the script is re-exec'd under bash) for safer and more efficient evaluation.

Validation was verified with a comprehensive test suite covering various safe and dangerous path edge cases.

---
*PR created automatically by Jules for task [6206136858271589476](https://jules.google.com/task/6206136858271589476) started by @MiguelRodo*