### PR TITLE
Feature: Expose and manage renv.lock files used during container build

### DIFF
--- a/src/renv-cache/README.md
+++ b/src/renv-cache/README.md
@@ -155,6 +155,31 @@ You can place custom scripts in your renv subdirectories:
 
 These scripts receive the `pkgExclude` parameter and run in the project directory context.
 
+### Accessing Lockfiles at Runtime
+
+The feature automatically creates snapshots of the `renv.lock` files used during the image build (both the "restore" state and the "update" state, if updates were requested).
+
+You can interact with these internal snapshots using the `renv-lockfile-cache` CLI utility, which is automatically available on your path inside the built container:
+
+**List Available Lockfiles:**
+```bash
+renv-lockfile-cache --list
+```
+
+**Copy a Lockfile to your Workspace:**
+By default, the script will prefer the updated lockfile (if available) and will place it in your current directory:
+```bash
+renv-lockfile-cache --copy
+```
+
+You can also specify a custom path (either a directory or exact filename):
+```bash
+renv-lockfile-cache --copy ./my-project/
+renv-lockfile-cache --copy /workspaces/custom-name.lock
+```
+
+If multiple project configurations were used during the build, `--copy` will prompt you interactively to select which project's lockfile you want to extract.
+
 ## Package Restoration
 
 This feature uses [`renvvv::renvvv_restore()`](https://github.com/MiguelRodo/renvvv) for package restoration instead of the default `renv::restore()`. This provides more robust restoration logic that:

--- a/src/renv-cache/cmd/renv-lockfile-cache
+++ b/src/renv-cache/cmd/renv-lockfile-cache
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -e
+
+CACHE_DIR="/usr/local/share/renv-cache/lockfiles"
+
+usage() {
+    echo "Usage: renv-lockfile-cache [OPTIONS] [PATH]"
+    echo ""
+    echo "Options:"
+    echo "  --list           Lists all original renv.lock files saved to the internal cache during the build."
+    echo "  --copy [path]    Copies the appropriate renv.lock file to the specified location."
+    echo "                   Defaults to './renv.lock' if no path is specified."
+    echo "  -h, --help       Display this help message."
+    exit "${1:-0}"
+}
+
+if [ "$#" -eq 0 ]; then
+    usage 1
+fi
+
+ACTION=""
+TARGET_PATH="./renv.lock"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --list)
+            ACTION="list"
+            shift
+            ;;
+        --copy)
+            ACTION="copy"
+            shift
+            if [ -n "$1" ] && [[ ! "$1" == --* ]]; then
+                TARGET_PATH="$1"
+                shift
+            fi
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            if [ "$ACTION" == "copy" ] && [ "$TARGET_PATH" == "./renv.lock" ]; then
+               TARGET_PATH="$1"
+               shift
+            else
+               echo "[ERROR] Unknown option or too many arguments: $1"
+               usage 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$ACTION" ]; then
+    usage 1
+fi
+
+if [ ! -d "$CACHE_DIR" ]; then
+    echo "[INFO] Internal cache directory not found: $CACHE_DIR"
+    exit 0
+fi
+
+if [ "$ACTION" == "list" ]; then
+    echo "Available lockfiles:"
+
+    # Loop over projects
+    for proj_dir in "$CACHE_DIR"/*; do
+        if [ -d "$proj_dir" ]; then
+            proj_name=$(basename "$proj_dir")
+            echo "Project: $proj_name"
+            if [ -f "$proj_dir/restore/renv.lock" ]; then
+                echo "  - Restored state: $proj_dir/restore/renv.lock"
+            fi
+            if [ -f "$proj_dir/update/renv.lock" ]; then
+                echo "  - Updated state: $proj_dir/update/renv.lock"
+            fi
+        fi
+    done
+    exit 0
+fi
+
+if [ "$ACTION" == "copy" ]; then
+    # Path resolution
+    if [[ "$TARGET_PATH" == *"/renv.lock" ]] || [[ "$TARGET_PATH" == "renv.lock" ]]; then
+        # It's a file path
+        dest_dir=$(dirname "$TARGET_PATH")
+        dest_file="$TARGET_PATH"
+    else
+        # It's a directory path
+        dest_dir="$TARGET_PATH"
+        dest_file="${dest_dir}/renv.lock"
+    fi
+
+    # Project Selection
+    projects=()
+    for proj_dir in "$CACHE_DIR"/*; do
+        if [ -d "$proj_dir" ]; then
+            projects+=("$(basename "$proj_dir")")
+        fi
+    done
+
+    if [ ${#projects[@]} -eq 0 ]; then
+        echo "[ERROR] No projects found in cache."
+        exit 1
+    fi
+
+    SELECTED_PROJ=""
+    if [ ${#projects[@]} -eq 1 ]; then
+        SELECTED_PROJ="${projects[0]}"
+    else
+        if [ -t 0 ]; then
+            echo "Multiple projects found. Please select one:"
+            select proj in "${projects[@]}"; do
+                if [ -n "$proj" ]; then
+                    SELECTED_PROJ="$proj"
+                    break
+                else
+                    echo "Invalid selection."
+                fi
+            done
+        else
+            # Non-interactive, default to first
+            SELECTED_PROJ="${projects[0]}"
+            echo "[INFO] Non-interactive mode. Defaulting to project: $SELECTED_PROJ"
+        fi
+    fi
+
+    proj_dir="${CACHE_DIR}/${SELECTED_PROJ}"
+    SOURCE_LOCKFILE=""
+
+    # Preference for Updated Files
+    if [ -f "$proj_dir/update/renv.lock" ]; then
+        SOURCE_LOCKFILE="$proj_dir/update/renv.lock"
+        echo "[INFO] Selected updated state for project $SELECTED_PROJ"
+    elif [ -f "$proj_dir/restore/renv.lock" ]; then
+        SOURCE_LOCKFILE="$proj_dir/restore/renv.lock"
+        echo "[INFO] Selected restored state for project $SELECTED_PROJ"
+    else
+        echo "[ERROR] No renv.lock files found for project $SELECTED_PROJ"
+        exit 1
+    fi
+
+    # Create destination directories if needed
+    mkdir -p "$dest_dir"
+
+    # Copy with overwrite logic
+    if [ -f "$dest_file" ]; then
+        if [ -t 0 ]; then
+            read -p "File '$dest_file' exists. Overwrite? (y/N): " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Copy aborted."
+                exit 0
+            fi
+        else
+            echo "[INFO] Overwriting existing file: $dest_file (non-interactive)"
+        fi
+    fi
+
+    cp "$SOURCE_LOCKFILE" "$dest_file"
+    echo "[OK] Copied to $dest_file"
+fi

--- a/src/renv-cache/cmd/renv-restore
+++ b/src/renv-cache/cmd/renv-restore
@@ -392,67 +392,93 @@ restore() {
         export RENV_CONFIG_PAK_ENABLED=TRUE
     fi
 
-    # Determine which renvvv action to execute
-    local renvvv_action=""
-    if [ "$RESTORE" = "true" ] && [ "$UPDATE" = "true" ]; then
-        renvvv_action="restore_and_update"
-        echo "[INFO] Both restore and update requested - using renvvv_restore_and_update()"
-    elif [ "$RESTORE" = "true" ]; then
-        renvvv_action="restore"
-        echo "[INFO] Restore requested - using renvvv_restore()"
-    elif [ "$UPDATE" = "true" ]; then
-        renvvv_action="update"
-        echo "[INFO] Update requested - using renvvv_update()"
-    else
+    if [ "$RESTORE" != "true" ] && [ "$UPDATE" != "true" ]; then
         echo "[WARN] Neither restore nor update requested. Skipping."
         reset_pak_backend "$renv_config_pak_orig"
         return 0
     fi
 
-    # Use renvvv action safely
-    RENVVV_ACTION="$renvvv_action" Rscript -e "
-        if (!requireNamespace('renvvv', quietly = TRUE)) {
-            stop('renvvv not found. Please ensure it was installed by the feature.')
-        }
+    local project_name=$(basename "$(pwd)")
+    local internal_cache_dir="/usr/local/share/renv-cache/lockfiles"
 
-        # Activate the project first to ensure correct paths
-        if (file.exists('renv/activate.R')) {
-            source('renv/activate.R')
-        }
-
-        # Parse packages to skip from environment variable
-        pkg_exclude_str <- Sys.getenv('PKG_EXCLUDE', '')
-        skip_packages <- if (nzchar(pkg_exclude_str)) {
-            # Split by comma and trim whitespace
-            trimws(unlist(strsplit(pkg_exclude_str, ',')))
-        } else {
-            character(0)
-        }
-
-        if (length(skip_packages) > 0) {
-            message('Skipping packages: ', paste(skip_packages, collapse = ', '))
-        }
-
-        action <- Sys.getenv('RENVVV_ACTION')
-        if (nzchar(action)) {
+    if [ "$RESTORE" = "true" ]; then
+        echo "[INFO] Restore requested - using renvvv_restore()"
+        RENVVV_ACTION="restore" Rscript -e "
+            if (!requireNamespace('renvvv', quietly = TRUE)) {
+                stop('renvvv not found. Please ensure it was installed by the feature.')
+            }
+            if (file.exists('renv/activate.R')) {
+                source('renv/activate.R')
+            }
+            pkg_exclude_str <- Sys.getenv('PKG_EXCLUDE', '')
+            skip_packages <- if (nzchar(pkg_exclude_str)) trimws(unlist(strsplit(pkg_exclude_str, ','))) else character(0)
+            if (length(skip_packages) > 0) message('Skipping packages: ', paste(skip_packages, collapse = ', '))
             tryCatch({
-                if (action == 'restore_and_update') {
-                    renvvv::renvvv_restore_and_update(skip = skip_packages)
-                } else if (action == 'restore') {
-                    renvvv::renvvv_restore(skip = skip_packages)
-                } else if (action == 'update') {
-                    renvvv::renvvv_update(skip = skip_packages)
-                } else {
-                    message('[WARN] Unknown renvvv action.')
-                }
+                renvvv::renvvv_restore(skip = skip_packages)
             }, error = function(e) {
-                    message('[WARN] renvvv operation failed: ', e)
-                    quit(status = 1)
+                message('[WARN] renvvv operation failed: ', e)
+                quit(status = 1)
             })
-        } else {
-            message('[WARN] No renvvv action provided.')
-        }
-    "
+        "
+
+        if [ -f "renv.lock" ]; then
+            echo "[INFO] Taking Build-Time Snapshot for RESTORE state"
+            # Pre-Snapshot Workaround
+            if command -v jq >/dev/null 2>&1; then
+                jq -r '.Packages | keys[]' renv.lock | while read -r pkg; do
+                    echo "library($pkg)" >> _dependencies.R
+                done
+            fi
+
+            local restore_snap_dir="${internal_cache_dir}/${project_name}/restore"
+            mkdir -p "$restore_snap_dir"
+            Rscript -e "
+                if (file.exists('renv/activate.R')) source('renv/activate.R')
+                renv::snapshot(lockfile = '${restore_snap_dir}/renv.lock', prompt = FALSE)
+            "
+        fi
+    fi
+
+    if [ "$UPDATE" = "true" ]; then
+        echo "[INFO] Update requested - using renvvv_update()"
+        RENVVV_ACTION="update" Rscript -e "
+            if (!requireNamespace('renvvv', quietly = TRUE)) {
+                stop('renvvv not found. Please ensure it was installed by the feature.')
+            }
+            if (file.exists('renv/activate.R')) {
+                source('renv/activate.R')
+            }
+            pkg_exclude_str <- Sys.getenv('PKG_EXCLUDE', '')
+            skip_packages <- if (nzchar(pkg_exclude_str)) trimws(unlist(strsplit(pkg_exclude_str, ','))) else character(0)
+            if (length(skip_packages) > 0) message('Skipping packages: ', paste(skip_packages, collapse = ', '))
+            tryCatch({
+                renvvv::renvvv_update(skip = skip_packages)
+            }, error = function(e) {
+                message('[WARN] renvvv operation failed: ', e)
+                quit(status = 1)
+            })
+        "
+
+        if [ -f "renv.lock" ]; then
+            echo "[INFO] Taking Build-Time Snapshot for UPDATE state"
+            # Pre-Snapshot Workaround
+            if command -v jq >/dev/null 2>&1; then
+                > _dependencies.R # Clear it first
+                jq -r '.Packages | keys[]' renv.lock | while read -r pkg; do
+                    echo "library($pkg)" >> _dependencies.R
+                done
+            fi
+
+            local update_snap_dir="${internal_cache_dir}/${project_name}/update"
+            mkdir -p "$update_snap_dir"
+            Rscript -e "
+                if (file.exists('renv/activate.R')) source('renv/activate.R')
+                renv::snapshot(lockfile = '${update_snap_dir}/renv.lock', prompt = FALSE)
+            "
+        fi
+    fi
+
+    rm -f _dependencies.R
     echo "[OK] Restore/update process attempted"
     echo "---------------------------------------------"
 

--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -253,6 +253,7 @@ restore() {
     # Copy and set execute permissions for renv restore scripts
     copy_and_set_execute_bit renv-restore
     copy_and_set_execute_bit renv-restore-build
+    copy_and_set_execute_bit renv-lockfile-cache
 
     # set renv cache mode and user
     debug "USERNAME: $USERNAME"


### PR DESCRIPTION
This Pull Request implements build-time snapshots of the R environment in the `renv-cache` DevContainer feature, fulfilling the requested issue. 

It accomplishes the following:
1. **Build-Time Snapshots**: The `renv-restore` script has been updated so that when packages are restored or updated, it temporarily extracts the package list using `jq`, generates a `_dependencies.R` file, and leverages `renv::snapshot()` to save the precise state of the package library to a hidden internal cache (`/usr/local/share/renv-cache/lockfiles/`).
2. **CLI Utility**: It introduces a new `renv-lockfile-cache` CLI utility installed on the system path. Users can run `--list` to see which lockfiles were captured across all parsed configurations. They can also run `--copy` to interactively or automatically copy the correct `renv.lock` file into their active workspace, resolving paths appropriately and prompting on overwrites.
3. **Documentation**: The feature's README is updated to clearly demonstrate how to interact with the runtime lockfile cache.

---
*PR created automatically by Jules for task [15495772244013266388](https://jules.google.com/task/15495772244013266388) started by @MiguelRodo*