### PR TITLE
🧪 Add tests for get_best_token in github-pat

### DIFF
--- a/test/github-tokens/cmd/github-pat.test.sh
+++ b/test/github-tokens/cmd/github-pat.test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)/src/github-tokens/cmd/github-pat"
+
+echo "🧪 Running tests for get_best_token"
+
+fails=0
+
+# Helper to run tests in a subshell
+run_test() {
+    local test_name="$1"
+    local expected="$2"
+    shift 2
+    local result
+
+    # Run in a subshell to isolate environment variables
+    # We use a subshell to prevent the sourced script's side effects
+    # from affecting the parent shell.
+    result=$(
+        # Unset variables to ensure clean state
+        unset GITHUB_PAT GH_TOKEN GITHUB_TOKEN
+
+        # Set environment variables passed to the function
+        eval "$*"
+
+        # Source the script
+        source "$SCRIPT_PATH" >/dev/null 2>&1
+
+        # Call the function
+        get_best_token
+    )
+
+    if [ "$result" = "$expected" ]; then
+        echo "✅ PASS: $test_name"
+    else
+        echo "❌ FAIL: $test_name (Expected: '$expected', Got: '$result')"
+        fails=$((fails + 1))
+    fi
+}
+
+run_test "GITHUB_PAT has highest priority" "pat_token" \
+    'export GITHUB_PAT="pat_token" GH_TOKEN="gh_token" GITHUB_TOKEN="github_token"'
+
+run_test "GH_TOKEN is used if GITHUB_PAT is missing" "gh_token" \
+    'export GH_TOKEN="gh_token" GITHUB_TOKEN="github_token"'
+
+run_test "GITHUB_TOKEN is used if others are missing" "github_token" \
+    'export GITHUB_TOKEN="github_token"'
+
+run_test "Empty string returned if no tokens are set" "" \
+    'true'
+
+if [ "$fails" -gt 0 ]; then
+    echo "❌ $fails tests failed!"
+    exit 1
+fi
+
+echo "🎉 All tests passed!"


### PR DESCRIPTION
🎯 **What:** Adds missing unit test coverage for the `get_best_token` function in the `src/github-tokens/cmd/github-pat` script.
📊 **Coverage:** Tests check the hierarchical priority explicitly, testing scenarios where `GITHUB_PAT` has highest priority, `GH_TOKEN` is chosen if `GITHUB_PAT` is missing, `GITHUB_TOKEN` is the final fallback, and the scenario where no tokens are provided returning an empty string.
✨ **Result:** Enhanced test coverage providing a reliable safety net for any future refactoring to GitHub token management features. The subshell isolation pattern protects the CI environment variables from being tainted by the test logic.

---
*PR created automatically by Jules for task [1616498266053904172](https://jules.google.com/task/1616498266053904172) started by @MiguelRodo*