### PR TITLE
🔒 fix: prevent sudo option injection in mmdc script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Path/URL manipulation and injection caused by unvalidated dynamic variables (e.g., dynamically fetching latest version strings via API calls).
 **Learning:** Variables that determine file paths or download URLs, even when fetched from typically trusted external sources (like a GitHub API), must be treated as untrusted input. If an API response is manipulated or unexpected (e.g., changing a version string to `../../../etc/passwd` or embedding shell commands), it can lead to path traversal, arbitrary file writes, or URL redirection vulnerabilities.
 **Prevention:** Always validate dynamically fetched data (like tags or version strings) against strict allow-lists (using POSIX-compliant regex like `^[0-9]+\.[0-9]+\.[0-9]+$`) before interpolating them into paths, URLs, or executing them.
+
+## 2024-05-15 - Sudo Option Injection Prevention
+**Vulnerability:** Option injection during privilege escalation.
+**Learning:** When invoking `sudo` with user-controlled or variable arguments, specifically when forwarding positional parameters (`$@`), it's possible for those arguments to be interpreted as options to `sudo` itself (e.g. `-i`, `-s`, etc.) if not explicitly delimited.
+**Prevention:** Always use the end-of-options delimiter (`--`) immediately preceding the command to execute when calling `sudo` (e.g. `sudo -u "$USERNAME" -- cmd "$@"`).

--- a/src/mermaid/cmd/mmdc
+++ b/src/mermaid/cmd/mmdc
@@ -75,7 +75,7 @@ if [ "$EUID" -eq 0 ]; then
 else
     # Not running as root, check for sudo
     if command -v sudo &>/dev/null; then
-        sudo -u "$USERNAME" mmdc -p "$CONFIG_FILE" "$@"
+        sudo -u "$USERNAME" -- mmdc -p "$CONFIG_FILE" "$@"
     else
         echo "Error: Not root and no 'sudo' available to switch user."
         exit 1


### PR DESCRIPTION
🎯 **What:** Fixed a potential option injection vulnerability in `src/mermaid/cmd/mmdc` when executing `sudo`.
⚠️ **Risk:** If a user managed to pass options starting with `-` to the script, they could potentially inject arguments into the `sudo` command itself, potentially leading to unauthorized privilege escalation or unexpected behavior.
🛡️ **Solution:** Added the `--` end-of-options delimiter to the `sudo` call (`sudo -u "$USERNAME" -- mmdc ...`), forcing `sudo` to treat all subsequent arguments as the command to execute, neutralizing the option injection vector.

---
*PR created automatically by Jules for task [5765281476970171348](https://jules.google.com/task/5765281476970171348) started by @MiguelRodo*