### PR TITLE
🧹 Refactor `install_pak` to use `install_pkg` in `renv-restore`

### DIFF
--- a/src/renv-cache/cmd/renv-restore
+++ b/src/renv-cache/cmd/renv-restore
@@ -250,49 +250,26 @@ restore_renv() {
 }
 
 install_pak() {
-    echo "Installing pak"
-    set_debug_renv
-    local renv_config_pak_orig="$RENV_CONFIG_PAK_ENABLED"
-    if [ "$renv_config_pak_orig" = "true" ]; then
-        export RENV_CONFIG_PAK_ENABLED=false
-    fi
-    local version="stable"
-    PAK_VERSION="$version" Rscript -e "
-    tryCatch(
-        {
-            if (isFALSE(requireNamespace('pak', quietly = TRUE))) {
-                message('pak not found. Installing pak...')
-                version <- Sys.getenv('PAK_VERSION')
-                install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/%s/%s/%s/%s\", version, .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))
-            } else {
-                message('[OK] pak is already installed.')
-            }
-        },
-        error = function(e) {
-            message('[WARN] Installation failed: ', e)
-        }
-    )"
-    if [ "$renv_config_pak_orig" = "true" ]; then
-        export RENV_CONFIG_PAK_ENABLED=true
-    fi
-    echo "[OK] Installation process attempted"
-    echo "---------------------------------------------"
+    PAK_VERSION="stable" install_pkg "pak" "sprintf('https://r-lib.github.io/p/pak/%s/%s/%s/%s', Sys.getenv('PAK_VERSION'), .Platform\$pkgType, R.Version()\$os, R.Version()\$arch)"
 }
 
 install_pkg() {
-    echo "Installing $1"
+    local pkg_name="$1"
+    local repos_expr="${2:-"'https://cloud.r-project.org'"}"
+
+    echo "Installing $pkg_name"
     set_debug_renv
     local renv_config_pak_orig="$RENV_CONFIG_PAK_ENABLED"
     if [ "$renv_config_pak_orig" = "true" ]; then
         export RENV_CONFIG_PAK_ENABLED=false
     fi
-    PKG_TO_INSTALL="$1" Rscript -e "
+    PKG_TO_INSTALL="$pkg_name" Rscript -e "
     tryCatch(
         {
             pkg <- Sys.getenv('PKG_TO_INSTALL')
             if (isFALSE(requireNamespace(pkg, quietly = TRUE))) {
                 message(pkg, ' not found. Installing ', pkg, '...')
-                utils::install.packages(pkg, repos = 'https://cloud.r-project.org')
+                utils::install.packages(pkg, repos = ${repos_expr})
             } else {
                 message('[OK] ', pkg, ' is already installed.')
             }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `install_pak` function in `src/renv-cache/cmd/renv-restore` contained largely duplicated R package installation logic (including configuring temporary backend flags, setting up Rscript calls, and handling tryCatch blocks) that was already present in `install_pkg`.

💡 **Why:** How this improves maintainability
By abstracting the repository parameter into `install_pkg`, we can cleanly call it from `install_pak`, avoiding nearly 30 lines of duplicate Rscript logic and ensuring that future updates to package installation routines are centralized in one place.

✅ **Verification:** How you confirmed the change is safe
- Used `bash -n` to verify the modified script's syntax.
- Manually audited the `Rscript -e` payload logic in `install_pkg` to ensure the repository variable is correctly passed in and expanded inside the R runtime.
- Confirmed there are no unexpected side effects or missing fallbacks (the default CRAN repo is properly retained).

✨ **Result:** The improvement achieved
A cleaner, DRY-compliant bash script with a single, resilient source of truth for R package installations.

---
*PR created automatically by Jules for task [3735569376186221517](https://jules.google.com/task/3735569376186221517) started by @MiguelRodo*