### PR TITLE
🧹 [code health improvement] simplify directory traversal checks in renv-cache

### DIFF
--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -95,7 +95,7 @@ empty_dir() {
     fi
 
     # Block path traversal and root-equivalent segments ( . and .. )
-    if [[ "$directory" == *"/./"* || "$directory" == *"/../"* || "$directory" == "/." || "$directory" == "/.." || "$directory" == */. || "$directory" == */.. ]]; then
+    if [[ "$directory" =~ (/\.($|/)|/\.\.($|/)) ]]; then
         echo "[ERROR] Refusing to empty directory: '$directory' (unsafe segment: . or ..)"
         return 1
     fi
@@ -132,7 +132,7 @@ rm_dirs() {
         fi
 
         # Block path traversal and root-equivalent segments ( . and .. )
-        if [[ "$dir" == *"/./"* || "$dir" == *"/../"* || "$dir" == "/." || "$dir" == "/.." || "$dir" == */. || "$dir" == */.. ]]; then
+        if [[ "$dir" =~ (/\.($|/)|/\.\.($|/)) ]]; then
             echo "[ERROR] Refusing to remove directory: '$dir' (unsafe segment: . or ..)"
             continue
         fi


### PR DESCRIPTION
🎯 **What:** Simplified the directory path traversal validation checks in `src/renv-cache/install.sh`'s `empty_dir` and `rm_dirs` functions.
💡 **Why:** The previous implementation used six explicit string match conditions connected by logical ORs, making the code highly verbose. The refactor replaces this with a single, concise extended regular expression.
✅ **Verification:** Verified that the regex preserves the exact original behavior via standalone bash testing scripts: it correctly blocks path traversal values (e.g., `/foo/../bar`, `/.`) while safely allowing valid hidden folders (e.g., `/.hidden`). Passed syntax checks with `bash -n`.
✨ **Result:** A significant improvement in maintainability and readability by cutting down duplicated, verbose conditional logic.

---
*PR created automatically by Jules for task [14194312082766388640](https://jules.google.com/task/14194312082766388640) started by @MiguelRodo*