### PR TITLE
🧪 [testing improvement] Add isolated tests for get_elevated_token and get_best_token

### DIFF
--- a/test/_global/github-tokens-functions.sh
+++ b/test/_global/github-tokens-functions.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+echo "🧪 Testing github-tokens internal functions (get_best_token, get_elevated_token)"
+
+# Path to the script we are testing
+GITHUB_PAT_SCRIPT="/usr/local/bin/github-tokens-github-pat"
+
+# Function to run a test case in a subshell
+run_test() {
+    local label="$1"
+    local env_setup="$2"
+    local func_to_test="$3"
+    local expected_output="$4"
+
+    # We use a subshell to isolate the test case and prevent environment leakage
+    check "$label" bash -c "
+        $env_setup
+        source $GITHUB_PAT_SCRIPT > /dev/null 2>&1
+        result=\$($func_to_test)
+        if [ \"\$result\" = \"$expected_output\" ]; then
+            exit 0
+        else
+            echo \"Expected '$expected_output' but got '\$result'\"
+            exit 1
+        fi
+    "
+}
+
+# --- Tests for get_best_token ---
+# Priority: GITHUB_PAT > GH_TOKEN > GITHUB_TOKEN
+
+run_test "get_best_token: GITHUB_PAT has highest priority" \
+    "export GITHUB_PAT=pat_val; export GH_TOKEN=gh_val; export GITHUB_TOKEN=gt_val" \
+    "get_best_token" "pat_val"
+
+run_test "get_best_token: GH_TOKEN fallback" \
+    "unset GITHUB_PAT; export GH_TOKEN=gh_val; export GITHUB_TOKEN=gt_val" \
+    "get_best_token" "gh_val"
+
+run_test "get_best_token: GITHUB_TOKEN fallback" \
+    "unset GITHUB_PAT; unset GH_TOKEN; export GITHUB_TOKEN=gt_val" \
+    "get_best_token" "gt_val"
+
+run_test "get_best_token: empty if none set" \
+    "unset GITHUB_PAT; unset GH_TOKEN; unset GITHUB_TOKEN" \
+    "get_best_token" ""
+
+# --- Tests for get_elevated_token ---
+# Priority: GITHUB_PAT > GH_TOKEN (excludes GITHUB_TOKEN)
+
+run_test "get_elevated_token: GITHUB_PAT priority" \
+    "export GITHUB_PAT=pat_val; export GH_TOKEN=gh_val; export GITHUB_TOKEN=gt_val" \
+    "get_elevated_token" "pat_val"
+
+run_test "get_elevated_token: GH_TOKEN priority" \
+    "unset GITHUB_PAT; export GH_TOKEN=gh_val; export GITHUB_TOKEN=gt_val" \
+    "get_elevated_token" "gh_val"
+
+run_test "get_elevated_token: empty if GITHUB_TOKEN is the only one set" \
+    "unset GITHUB_PAT; unset GH_TOKEN; export GITHUB_TOKEN=gt_val" \
+    "get_elevated_token" ""
+
+# Report result
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -57,6 +57,12 @@
             "GH_TOKEN": "ghp_permissive_token"
         }
    },
+   "github-tokens-functions": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "github-tokens": {}
+        }
+   },
    "github-tokens-override": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `get_elevated_token` and `get_best_token` functions in the `github-pat` script were previously untested in isolation. These functions are critical for determining which authentication token to use, following a specific priority order.

### 📊 Coverage: What scenarios are now tested
The new `github-tokens-functions` scenario covers:
- **get_best_token**: Verifies priority `GITHUB_PAT > GH_TOKEN > GITHUB_TOKEN`.
- **get_elevated_token**: Verifies priority `GITHUB_PAT > GH_TOKEN` and ensures it correctly falls back to empty if only `GITHUB_TOKEN` is set.
- Handles cases where none of the tokens are set.

### ✨ Result: The improvement in test coverage
By adding these isolated functional tests, we ensure that the core token selection logic is robust and won't regress when the script is refactored or updated. The tests use subshell isolation to prevent environment leakage between test cases.

---
*PR created automatically by Jules for task [16027632828497331161](https://jules.google.com/task/16027632828497331161) started by @MiguelRodo*